### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ php composer.phar install
 
 ```
 cd EC-CUBE/app/Plugin
-git clone https://github.com/payjp/payjp-eccube.git
+git clone https://github.com/payjp/payjp-eccube.git PayJp
 ```
 
 - プラグインをコマンドラインからインストールします。


### PR DESCRIPTION
CLIからインストールする場合、ディレクトリ名を指定しているようなので、clone時のディレクトリ名「payjp-eccube」ではインストールに失敗します。

clone時にディレクトリ名を指定しておくと成功します。