### PR TITLE
Erase column length restriction

### DIFF
--- a/Migration/Version20160417000100.php
+++ b/Migration/Version20160417000100.php
@@ -45,13 +45,13 @@ class Version20160417000100 extends AbstractMigration
 
         $table = $schema->createTable("plg_pay_jp_token");
         $table->addColumn('id', 'string', array('length' => 16, 'notnull' => true));
-        $table->addColumn('pay_jp_token', 'string', array('length' => 40, 'notnull' => true));
+        $table->addColumn('pay_jp_token', 'string', array('notnull' => true));
         $table->addColumn('created_at', 'datetime');
         $table->setPrimaryKey(array('id'));
 
         $table = $schema->createTable("plg_pay_jp_config");
         $table->addColumn('id', 'integer', array('notnull' => true));
-        $table->addColumn('api_key_secret', 'string', array('length' => 40, 'notnull' => true));
+        $table->addColumn('api_key_secret', 'string', array('notnull' => true));
         $table->addColumn('created_at', 'datetime');
         $table->setPrimaryKey(array('id'));
 


### PR DESCRIPTION
fix #3 

- カラムの長さが本番秘密鍵を保存するのに十分でなかった問題を修正しました
- PAY.JPにより発行されるTokenを保存するカラムの長さ制限についても、特になにかの仕様に沿ったものではないため削除しました